### PR TITLE
Update asyncio call

### DIFF
--- a/gitlab-skyline
+++ b/gitlab-skyline
@@ -183,7 +183,7 @@ def main():
     print("Fetching contributions from Gitlab...")
 
     semaphore = asyncio.Semaphore(max_requests)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     loop.run_until_complete(
         asyncio.wait(
             [get_contributions(semaphore, domain, username, token, date, contribution_matrix) for date in


### PR DESCRIPTION
According to [this stackoverflow post](https://stackoverflow.com/questions/73361664/asyncio-get-event-loop-deprecationwarning-there-is-no-current-event-loop), this is how this api will need to be used in the future[](url)